### PR TITLE
Fix "Area code is already set" on Magento 2.1

### DIFF
--- a/Console/Command/ChangePassword.php
+++ b/Console/Command/ChangePassword.php
@@ -100,7 +100,9 @@ class ChangePassword extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_appState->setAreaCode('adminhtml');
+        if (!$this->_appState->getAreaCode()) {
+            $this->_appState->setAreaCode('adminhtml');
+        }
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');


### PR DESCRIPTION
Seems like at some point Magento introduced a validation in `setAreaCode` that throws the above mentioned error if an area code has already been set.